### PR TITLE
Add h5 font size

### DIFF
--- a/src/pages/docs.css
+++ b/src/pages/docs.css
@@ -56,6 +56,9 @@ p {
 .documentwrapper h4 {
   font-size: 22px;
 }
+.documentwrapper h5 {
+  font-size: 22px;
+}
 .headerlink {
   display: none;
 }


### PR DESCRIPTION
The h5 tag was missing a font size so it looks really small. This PR adds a font size for h5 tags.

Before:

<img width="1227" alt="Screenshot 2019-12-26 19 45 28" src="https://user-images.githubusercontent.com/691952/71488445-6e1de300-2818-11ea-983c-89525393e3aa.png">

After:

<img width="1202" alt="Screenshot 2019-12-26 19 45 46" src="https://user-images.githubusercontent.com/691952/71488447-7118d380-2818-11ea-9584-ded1d17b697b.png">
